### PR TITLE
Handling requests in a thread to allow blocking code in tests

### DIFF
--- a/MockHttpServer/MockServer.cs
+++ b/MockHttpServer/MockServer.cs
@@ -17,7 +17,16 @@ namespace MockHttpServer
         private Task _handleRequestsTask;
         private const int ListenerStoppedErrorCode = 995;
 
-        public IReadOnlyList<MockHttpHandler> RequestHandlers => _requestHandlers;
+        public IReadOnlyList<MockHttpHandler> RequestHandlers
+        {
+            get
+            {
+                lock (_requestHandlersLock)
+                {
+                    return new List<MockHttpHandler>(_requestHandlers);
+                }
+            }
+        }
 
         public int Port { get; }
 

--- a/MockHttpServer/MockServer.cs
+++ b/MockHttpServer/MockServer.cs
@@ -14,7 +14,6 @@ namespace MockHttpServer
         private List<MockHttpHandler> _requestHandlers;
         private readonly object _requestHandlersLock = new object();
         private readonly Action<HttpListenerRequest, HttpListenerResponse, Dictionary<string, string>> _preHandler; //if set, this will be executed for every request before the handler is called
-        private readonly string _hostName; //the hostname to listen on.  defaults to localhost, but if you run as admin, you can use * or + as wild cards.  if a port is registered by netsh with a * or +, you can specify it in the constructor to use the wildcard without admin rights
         private Task _handleRequestsTask;
         private const int ListenerStoppedErrorCode = 995;
 
@@ -44,13 +43,12 @@ namespace MockHttpServer
         {
             _requestHandlers = requestHandlers.ToList(); //make a copy of the items, in case they get cleared later
             _preHandler = preHandler;
-            _hostName = hostName;
 
             Port = port > 0 ? port : GetRandomUnusedPort();
 
             //create and start listener
             _listener = new HttpListener();
-            _listener.Prefixes.Add($"http://{_hostName}:{Port}/");
+            _listener.Prefixes.Add($"http://{hostName}:{Port}/");
             _listener.Start();
 
             _handleRequestsTask = Task.Run(HandleRequests);

--- a/MockHttpServer/MockServer.cs
+++ b/MockHttpServer/MockServer.cs
@@ -121,7 +121,8 @@ namespace MockHttpServer
                         {
                             var buffer = Encoding.UTF8.GetBytes(responseString);
                             context.Response.ContentLength64 += buffer.Length;
-                            context.Response.OutputStream.Write(buffer, 0, buffer.Length);
+                            await context.Response.OutputStream.WriteAsync(
+                                buffer, 0, buffer.Length);
                         }
                     }
                     finally

--- a/MockHttpServer/MockServer.cs
+++ b/MockHttpServer/MockServer.cs
@@ -77,8 +77,8 @@ namespace MockHttpServer
 
                     try
                     {
-                        //determine the hanlder
-                        Dictionary<string, string> parameters = null;
+                        //determine the handler
+                        var parameters = new Dictionary<string, string>();
                         MockHttpHandler handler;
                         lock (_requestHandlersLock)
                         {
@@ -86,7 +86,7 @@ namespace MockHttpServer
                         }
 
                         //run the shared pre-handler
-                        _preHandler?.Invoke(context.Request, context.Response, parameters ?? new Dictionary<string, string>());
+                        _preHandler?.Invoke(context.Request, context.Response, parameters);
 
                         //get the response string
                         string responseString = null;


### PR DESCRIPTION
I was running into trouble using this library on single-core machines with non-async tests. The async function requires that the thread is not blocked, so requests would hang.

I changed it so the requests are handled in the background.

This is published on NuGet under [AT.MockHttpServer](https://www.nuget.org/packages/AT.MockHttpServer). If this is merged and published under AP.MockHttpServer then I can remove the package.